### PR TITLE
Use main branch of tdr-github-actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ permissions:
   contents: read
 jobs:
   test:
-    uses: nationalarchives/tdr-github-actions/.github/workflows/tdr_test.yml@add-set-python-version
+    uses: nationalarchives/tdr-github-actions/.github/workflows/tdr_test.yml@main
     with:
       repo-name: tdr-signed-cookies
       test-command: |


### PR DESCRIPTION
I added this when I needed python3.9 but now I need 3.8 which is the
default on the runners so this isn't needed.
