### PR TITLE
Extend cookie expiry

### DIFF
--- a/src/signed_cookies.py
+++ b/src/signed_cookies.py
@@ -15,8 +15,8 @@ from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import padding
 
 
-def thirty_minutes():
-    return int(time.time()) + (60 * 30)
+def sixty_minutes():
+    return int(time.time()) + (60 * 60)
 
 
 def _replace_unsupported_chars(some_str):
@@ -42,7 +42,7 @@ def generate_policy_cookie(url):
                 "Resource": url,
                 "Condition": {
                     "DateLessThan": {
-                        "AWS:EpochTime": thirty_minutes()
+                        "AWS:EpochTime": sixty_minutes()
                     }
                 }
             }

--- a/test/test_signed_cookies.py
+++ b/test/test_signed_cookies.py
@@ -66,7 +66,7 @@ def test_access_control_origin(environment, origin, allowed_origin, frontend_url
 
 @patch('time.time', mock_time)
 def test_create_cookie_policy(kms, httpserver: HTTPServer):
-    expected_time = mock_time_return_value + (60 * 30)
+    expected_time = mock_time_return_value + (60 * 60)
     token_expiry_time = math.ceil(current_time) + 3600
     user_id = str(uuid.uuid4())
     url = f"https://upload.example.com/{user_id}/*"


### PR DESCRIPTION
Cookie is renewed before a user's idle session timeout is reached. This timeout was extended to 60 mins, so the cookie was expiring before renewal, causing uploads of longer than 30mins to fail