### PR TITLE
Make cookie expiry configurable

### DIFF
--- a/src/signed_cookies.py
+++ b/src/signed_cookies.py
@@ -15,8 +15,9 @@ from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import padding
 
 
-def sixty_minutes():
-    return int(time.time()) + (60 * 60)
+def cookie_expiry():
+    expiry_mins = os.environ["COOKIE_EXPIRY_MINUTES"]
+    return int(time.time()) + (60 * int(expiry_mins))
 
 
 def _replace_unsupported_chars(some_str):
@@ -42,7 +43,7 @@ def generate_policy_cookie(url):
                 "Resource": url,
                 "Condition": {
                     "DateLessThan": {
-                        "AWS:EpochTime": sixty_minutes()
+                        "AWS:EpochTime": cookie_expiry()
                     }
                 }
             }

--- a/test/utils/utils.py
+++ b/test/utils/utils.py
@@ -113,6 +113,7 @@ def set_up(kms, httpserver):
     os.environ['AWS_ACCESS_KEY_ID'] = 'testing'
     os.environ['AWS_SECRET_ACCESS_KEY'] = 'testing'
     os.environ['AWS_DEFAULT_REGION'] = 'eu-west-2'
+    os.environ['COOKIE_EXPIRY_MINUTES'] = '60'
 
 
 def decode_string(cookie_string):


### PR DESCRIPTION
To accommodate larger consignments may need to temporarily increase session timeout from standard 60minutes