### PR TITLE
Allow uploads from Sharepoint via cloudfront proxy

### DIFF
--- a/src/signed_cookies.py
+++ b/src/signed_cookies.py
@@ -70,11 +70,30 @@ def decode(env_var_name):
     return decoded["Plaintext"].decode("utf-8")
 
 
-def user_id_from_token(token, url):
+def sharepoint_domain(origin):
+    return "sharepoint.com" in origin
+
+
+def get_audience(origin):
+    if sharepoint_domain(origin):
+        return "tdr-sharepoint"
+    else:
+        return "tdr-fe"
+
+
+def get_allowed_origin(origin, environment, frontend_url):
+    if sharepoint_domain(origin) or (environment == "integration" and origin == "http://localhost:9000"):
+        return origin
+    else:
+        return frontend_url
+
+
+def user_id_from_token(token, url, origin):
+    audience = get_audience(origin)
     jwks_client = PyJWKClient(f"{url}/realms/tdr/protocol/openid-connect/certs")
     signing_key = jwks_client.get_signing_key_from_jwt(token)
     options = {"verify_exp": True, "verify_signature": True}
-    payload = jwt.decode(token, signing_key.key, audience="tdr-fe", algorithms=["RS256"], options=options)
+    payload = jwt.decode(token, signing_key.key, audience=audience, algorithms=["RS256"], options=options)
     return payload["user_id"]
 
 
@@ -90,13 +109,13 @@ def sign_cookies(event):
     auth_url = os.environ["AUTH_URL"]
     upload_domain = os.environ["UPLOAD_DOMAIN"]
     frontend_url = os.environ["FRONTEND_URL"]
-    user_id = user_id_from_token(token, auth_url)
+    user_id = user_id_from_token(token, auth_url, origin)
     cookies = generate_signed_cookies(f"https://{upload_domain}/{user_id}/*", private_key, key_pair_id)
     return generate_response(cookies, environment, frontend_url, origin)
 
 
 def generate_response(cookies, environment, frontend_url, origin):
-    allowed_origin = origin if environment == "integration" and origin == "http://localhost:9000" else frontend_url
+    allowed_origin = get_allowed_origin(origin, environment, frontend_url)
     suffix = "Path=/; Secure; HttpOnly; SameSite=None"
     return {
         "statusCode": 200,

--- a/test/test_signed_cookies.py
+++ b/test/test_signed_cookies.py
@@ -17,6 +17,23 @@ def kms():
         yield boto3.client('kms', region_name='eu-west-2')
 
 
+sharepoint_origin = "https://some-subdomain.sharepoint.com/something/else"
+non_sharepoint_origin = "https://tdr.nationalarchives.gov.uk"
+
+
+def test_sharepoint_domain():
+    sharepoint_result = signed_cookies.sharepoint_domain(sharepoint_origin)
+    non_sharepoint_result = signed_cookies.sharepoint_domain(non_sharepoint_origin)
+    assert sharepoint_result == True
+    assert non_sharepoint_result == False
+
+
+@pytest.mark.parametrize("origin, audience", audience_test_values())
+def test_get_audience(origin, audience):
+    result = signed_cookies.get_audience(origin)
+    assert result == audience
+
+
 def test_unauthorised_for_invalid_token(kms, httpserver: HTTPServer):
     set_up(kms, httpserver)
     event = get_event("invalid_token")


### PR DESCRIPTION
TDR will allow uploading of objects from SharePoint to the dirty s3 bucket

Some of the settings in the signed cookie will need to be adjusted to allow this via the cloudfront proxy

The requests will come from a domain other than the TDR frontend and a different 'aud' value on the bearer access token